### PR TITLE
feat: add make, AWS CLI, and Terraform to the installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,9 @@ init_tools() {
     "zsh|Zsh + Starship|$MSG_TOOL_ZSH_DESC"
     "node|Node.js (fnm)|$MSG_TOOL_NODE_DESC"
     "docker|Docker|$MSG_TOOL_DOCKER_DESC"
+    "make|Make|$MSG_TOOL_MAKE_DESC"
+    "aws|AWS CLI|$MSG_TOOL_AWS_DESC"
+    "terraform|Terraform|$MSG_TOOL_TERRAFORM_DESC"
   )
 }
 
@@ -185,8 +188,11 @@ extract_version() {
     git)    ver=$(grep -oP 'git version \K[\d.]+' "$log_file" | tail -1) ;;
     zsh)    ver=$(grep -oP 'zsh \K[\d.]+' "$log_file" | tail -1) ;;
     node)   ver=$(grep -oP 'node v\K[\d.]+' "$log_file" | tail -1) ;;
-    docker) ver=$(grep -oP 'Docker version \K[\d.]+' "$log_file" | tail -1) ;;
-    *)      ver="" ;;
+    docker)    ver=$(grep -oP 'Docker version \K[\d.]+' "$log_file" | tail -1) ;;
+    make)      ver=$(grep -oP 'GNU Make \K[\d.]+' "$log_file" | tail -1) ;;
+    aws)       ver=$(grep -oP 'aws-cli/\K[\d.]+' "$log_file" | tail -1) ;;
+    terraform) ver=$(grep -oP 'Terraform v\K[\d.]+' "$log_file" | tail -1) ;;
+    *)         ver="" ;;
   esac
   echo "${ver:---}"
 }
@@ -258,7 +264,7 @@ select_tools() {
     --item.foreground "$C_DIM" \
     --selected-prefix "◉ " \
     --unselected-prefix "◯ " \
-    --height 8 \
+    --height 11 \
     "${options[@]}"
 }
 

--- a/lang/en.sh
+++ b/lang/en.sh
@@ -111,3 +111,19 @@ readonly MSG_TOOL_GIT_DESC="Version control"
 readonly MSG_TOOL_ZSH_DESC="Shell and prompt"
 readonly MSG_TOOL_NODE_DESC="JavaScript runtime + version manager"
 readonly MSG_TOOL_DOCKER_DESC="Container runtime"
+readonly MSG_TOOL_MAKE_DESC="Build automation"
+readonly MSG_TOOL_AWS_DESC="Amazon Web Services CLI"
+readonly MSG_TOOL_TERRAFORM_DESC="Infrastructure as Code"
+
+# make
+readonly MSG_MAKE_INSTALLING="Installing make..."
+readonly MSG_MAKE_ALREADY_INSTALLED="Already installed:"
+
+# aws cli
+readonly MSG_AWS_INSTALLING="Installing AWS CLI v2..."
+readonly MSG_AWS_ALREADY_INSTALLED="Already installed:"
+
+# terraform
+readonly MSG_TERRAFORM_INSTALLING="Installing Terraform..."
+readonly MSG_TERRAFORM_ALREADY_INSTALLED="Already installed:"
+readonly MSG_TERRAFORM_AUTOCOMPLETE="Terraform autocomplete configured"

--- a/lang/es.sh
+++ b/lang/es.sh
@@ -111,3 +111,19 @@ readonly MSG_TOOL_GIT_DESC="Control de versiones"
 readonly MSG_TOOL_ZSH_DESC="Shell y prompt"
 readonly MSG_TOOL_NODE_DESC="Runtime de JavaScript + gestor de versiones"
 readonly MSG_TOOL_DOCKER_DESC="Runtime de contenedores"
+readonly MSG_TOOL_MAKE_DESC="Automatización de compilación"
+readonly MSG_TOOL_AWS_DESC="CLI de Amazon Web Services"
+readonly MSG_TOOL_TERRAFORM_DESC="Infraestructura como Código"
+
+# make
+readonly MSG_MAKE_INSTALLING="Instalando make..."
+readonly MSG_MAKE_ALREADY_INSTALLED="Ya está instalado:"
+
+# aws cli
+readonly MSG_AWS_INSTALLING="Instalando AWS CLI v2..."
+readonly MSG_AWS_ALREADY_INSTALLED="Ya está instalado:"
+
+# terraform
+readonly MSG_TERRAFORM_INSTALLING="Instalando Terraform..."
+readonly MSG_TERRAFORM_ALREADY_INSTALLED="Ya está instalado:"
+readonly MSG_TERRAFORM_AUTOCOMPLETE="Autocompletado de Terraform configurado"

--- a/scripts/aws.sh
+++ b/scripts/aws.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v aws &>/dev/null; then
+  echo "› $MSG_AWS_ALREADY_INSTALLED $(aws --version 2>&1)"
+else
+  echo "› $MSG_AWS_INSTALLING"
+
+  [[ "${APT_UPDATED:-0}" == "1" ]] || sudo apt-get update -qq
+  sudo apt-get install -y unzip curl
+
+  local_tmp=$(mktemp -d)
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+    -o "$local_tmp/awscliv2.zip"
+  unzip -qo "$local_tmp/awscliv2.zip" -d "$local_tmp"
+  sudo "$local_tmp/aws/install"
+  rm -rf "$local_tmp"
+
+  echo "  $(aws --version 2>&1)"
+fi

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v make &>/dev/null; then
+  echo "› $MSG_MAKE_INSTALLING"
+  [[ "${APT_UPDATED:-0}" == "1" ]] || sudo apt-get update -qq
+  sudo apt-get install -y make
+  echo "  $(make --version | head -1)"
+else
+  echo "› $MSG_MAKE_ALREADY_INSTALLED $(make --version | head -1)"
+fi

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v terraform &>/dev/null; then
+  echo "› $MSG_TERRAFORM_ALREADY_INSTALLED $(terraform --version | head -1)"
+else
+  echo "› $MSG_TERRAFORM_INSTALLING"
+
+  [[ "${APT_UPDATED:-0}" == "1" ]] || sudo apt-get update -qq
+  sudo apt-get install -y gnupg software-properties-common
+
+  wget -qO- https://apt.releases.hashicorp.com/gpg \
+    | gpg --dearmor \
+    | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg > /dev/null
+
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com \
+$(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" \
+    | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null
+
+  sudo apt-get update -qq
+  sudo apt-get install -y terraform
+
+  echo "  $(terraform --version | head -1)"
+fi
+
+# Enable autocomplete (silently skip if already configured)
+terraform -install-autocomplete 2>/dev/null || true
+echo "› $MSG_TERRAFORM_AUTOCOMPLETE"


### PR DESCRIPTION
## Summary
- Add **Make** (build automation) installed via `apt`
- Add **AWS CLI v2** installed from the official Amazon zip archive
- Add **Terraform** installed from the HashiCorp apt repository with autocomplete support
- Register all three tools in the interactive installer menu with i18n support (English and Spanish)

## Changes
- `scripts/make.sh` — new install script for make
- `scripts/aws.sh` — new install script for AWS CLI v2
- `scripts/terraform.sh` — new install script for Terraform + autocomplete
- `install.sh` — register tools in `TOOLS` array, add version extraction patterns, increase menu height
- `lang/en.sh` — English translation strings
- `lang/es.sh` — Spanish translation strings

## Test plan
- [x] Run `bash -n` syntax check on all modified/new scripts
- [x] Run `./install.sh` and verify the three new tools appear in the selection menu
- [x] Install each tool individually and verify version is displayed in the summary table
- [x] Test with `--lang es` to verify Spanish translations

https://claude.ai/code/session_01JX37wsESiV3y5gNJdCiCV3